### PR TITLE
ホワイトノイズの追加

### DIFF
--- a/philox4x32.hpp
+++ b/philox4x32.hpp
@@ -1,0 +1,168 @@
+// 乱数生成器．n 番目までシークする時間が O(1) なので都合がよい．
+// ref: https://en.cppreference.com/w/cpp/numeric/random/philox_engine
+
+#pragma once
+
+#include <cstdint>
+#include <array>
+
+namespace my_rng
+{
+	template<std::size_t round, std::uint_fast32_t... consts>
+	struct philox32_base {
+		using result_type = std::uint_fast32_t;
+		constexpr static std::size_t word_count = sizeof... (consts);
+		constexpr static std::size_t word_size = 32;
+		constexpr static std::size_t round_count = round;
+		static_assert((word_count == 2 || word_count == 4) && (round_count > 0));
+
+	private:
+		template<size_t d, size_t r>
+		static consteval std::array<result_type, word_count / d> skipped_array() {
+			std::array<result_type, word_count / d> ret{};
+			std::array<result_type, word_count> src { consts... };
+			for (size_t k = 0; k < word_count / d; k++)
+				ret[k] = src[d * k + r];
+			return ret;
+		}
+
+	public:
+		constexpr static std::array<result_type, word_count / 2> multipliers = skipped_array<2, 0>();
+		constexpr static std::array<result_type, word_count / 2> round_consts = skipped_array<2, 1>();
+		constexpr static std::uint_least32_t default_seed = 20111115u;
+
+		static constexpr result_type min() { return 0u; }
+		static constexpr result_type max() { return ~0u; }
+
+		// constructors.
+		constexpr philox32_base() : philox32_base(default_seed) {}
+		constexpr explicit philox32_base(result_type value)
+		{
+			seed(value);
+		}
+		template<class seed_seq>
+		requires (!std::convertible_to<seed_seq, result_type> && !std::same_as<seed_seq, philox32_base>)
+		constexpr explicit philox32_base(seed_seq& seq)
+		{
+			seed(seq);
+		}
+
+		// seedings.
+		constexpr void seed(result_type value)
+		{
+			for (auto& x : X) x = 0;
+			K[0] = value; for (std::size_t k = 1; k < std::size(K); k++) K[k] = 0;
+			j = word_count - 1;
+		}
+		template<class seed_seq>
+			requires (!std::convertible_to<seed_seq, result_type>)
+		constexpr void seed(seed_seq& seq)
+		{
+			// reset Z.
+			for (auto& x : X) x = 0;
+
+			// handle seq.
+			result_type a[word_count / 2];
+			seq.generate(a + 0, a + word_count / 2);
+			for (std::size_t k = 0; k < word_count / 2; k++)
+				K[k] = a[k];
+
+			// reset j.
+			j = word_count - 1;
+		}
+		constexpr void set_couner(std::array<result_type, word_count> const& c)
+		{
+			for (std::size_t k = 0; k < word_count; k++)
+				X[k] = c[word_count - 1 - k];
+			j = word_count - 1;
+		}
+
+		// PRNG operations.
+		constexpr result_type operator()()
+		{
+			move_next();
+			return Y[j];
+		}
+		constexpr void discard(uint64_t z)
+		{
+			if (z < word_count - j) {
+				j += static_cast<std::size_t>(z);
+				return;
+			}
+
+			z += j;
+			j = z % word_count;
+			z /= word_count;
+
+			auto x01 = (static_cast<std::uint_fast64_t>(X[1]) << word_size) | X[0];
+			x01 += z;
+			X[0] = static_cast<result_type>(x01);
+			X[1] = static_cast<result_type>(x01 >> word_size);
+			if constexpr (word_count == 4) {
+				if (x01 < z) {
+					for (std::size_t k = 2; k < word_count && ++X[k] == 0; ++k);
+				}
+			}
+
+			if (j != word_count - 1) update();
+		}
+
+		// identify.
+		constexpr bool operator==(philox32_base const& rhs) const
+		{
+			return j == rhs.j
+				&& X == rhs.X
+				&& K == rhs.K;
+		}
+
+	private:
+		// implementations of PRNG.
+		std::size_t j = 0;
+		std::array<result_type, word_count> X; // represents a big integer Z = \sum_k 2^{w k} X_k.
+		std::array<result_type, word_count> Y; // generated sequence.
+		std::array<result_type, word_count / 2> K; // "key" sequence (essentially a seed).
+
+		constexpr void update_round(std::size_t q)
+		{
+			if constexpr (word_count == 4) {
+				auto x01 = static_cast<std::uint_fast64_t>(Y[2]) * multipliers[0];
+				auto x23 = static_cast<std::uint_fast64_t>(Y[0]) * multipliers[1];
+				Y[0] = static_cast<result_type>(x01 >> word_size)
+					^ static_cast<result_type>(K[0] + q * round_consts[0]) ^ Y[1];
+				Y[1] = static_cast<result_type>(x01);
+				Y[2] = static_cast<result_type>(x23 >> word_size)
+					^ static_cast<result_type>(K[1] + q * round_consts[1]) ^ Y[3];
+				Y[3] = static_cast<result_type>(x23);
+			}
+			else {
+				auto x01 = static_cast<std::uint_fast64_t>(Y[0]) * multipliers[0];
+				Y[0] = static_cast<result_type>(x01 >> word_size)
+					^ static_cast<result_type>(K[0] + q * round_consts[0]) ^ Y[1];
+				Y[1] = static_cast<result_type>(x01);
+			}
+		}
+		constexpr void update()
+		{
+			Y = X;
+			for (std::size_t q = 0; q < round_count; q++) update_round(q);
+		}
+		constexpr void move_next()
+		{
+			if (j != word_count - 1) j++;
+			else {
+				// generate Y.
+				update();
+
+				// increment Z.
+				for (size_t k = 0; k < word_count && ++X[k] == 0; ++k);
+
+				// reset j.
+				j = 0;
+			}
+		}
+	};
+
+	using philox4x32 = philox32_base<10,
+		0xCD9E8D57, 0x9E3779B9,
+		0xD2511F53, 0xBB67AE85>;
+}

--- a/src.cpp
+++ b/src.cpp
@@ -1,6 +1,9 @@
-﻿#include <windows.h>
+﻿#define NOMINMAX
+#include <windows.h>
 #include <algorithm>
+#include <cmath>
 #include "exedit.hpp"
+#include "philox4x32.hpp"
 
 constexpr int track_n = 1;
 constexpr int track_hz_scale = 100;
@@ -15,8 +18,8 @@ inline static int track_drag_min[track_n] = { 5500 };
 inline static int track_drag_max[track_n] = { 352000 };
 
 constexpr int check_n = 15;
-constexpr int type_n = 6;
-static char* check_name[check_n] = { const_cast<char*>("三角波\0のこぎり波\0正弦波\0矩形波\0パルス波1/4\0パルス波1/8\0"),
+constexpr int type_n = 7;
+static char* check_name[check_n] = { const_cast<char*>("三角波\0のこぎり波\0正弦波\0矩形波\0パルス波1/4\0パルス波1/8\0ホワイトノイズ\0"),
                                     const_cast<char*>("/2"),
                                     const_cast<char*>("C"),
                                     const_cast<char*>("C#"),
@@ -57,7 +60,11 @@ static ExEdit::ExdataUse exdata_use[] = {
 
 float preset_scale[12];
 
+intptr_t get_func_address(intptr_t call_address) {
+    return 4 + call_address + *reinterpret_cast<ptrdiff_t*>(call_address);
+}
 static void(__cdecl* update_any_exdata)(ExEdit::ObjectFilterIndex, const char*) = nullptr;
+static void*(__cdecl* get_or_create_cache)(ExEdit::ObjectFilterIndex ofi, int w, int h, int bitcount, int v_func_id, int* old_cache_exists) = nullptr;
 
 
 
@@ -99,6 +106,32 @@ short pulse_one_eighth(double rate) {
         return SHRT_MIN;
     }
 }
+struct noise_state {
+    short last_value; // 最後に生成した乱数値．
+    int waves; // 生成した乱数の個数．
+};
+struct {
+    noise_state state;
+    double step;
+    my_rng::philox4x32 rng;
+
+    void recall(int seed, noise_state const& state) {
+        this->state = state;
+        rng.seed(my_rng::philox4x32::default_seed + seed);
+        rng.discard(state.waves);
+    }
+    void move_next() {
+        state.waves++;
+        state.last_value = static_cast<short>(rng() >> 16);
+    }
+    short value() const { return state.last_value; }
+} noise_generator{};
+short white_noise(double rate) {
+    constexpr int noise_freq = 8; // 1周期当たりに発生する乱数の個数．
+    if (rate - std::floor(rate * noise_freq) / noise_freq < noise_generator.step)
+        noise_generator.move_next();
+    return noise_generator.value();
+}
 
 BOOL func_proc(ExEdit::Filter* efp, ExEdit::FilterProcInfo* efpip) {
     Exdata* exdata = reinterpret_cast<Exdata*>(efp->exdata_ptr);
@@ -126,6 +159,33 @@ BOOL func_proc(ExEdit::Filter* efp, ExEdit::FilterProcInfo* efpip) {
     double step = hz / (double)efpip->audio_rate;
 
 
+    // 乱数位置を記録するためのキャッシュ．
+    struct {
+        int frame;
+        noise_state states[2];
+    }* cache = nullptr;
+    if (exdata->type == 6) {
+        int cache_exists_flag;
+        cache = reinterpret_cast<decltype(cache)>(get_or_create_cache(
+            efp->processing, sizeof(*cache) / sizeof(short), 1, 8 * sizeof(short),
+            reinterpret_cast<int>(&white_noise), &cache_exists_flag));
+
+        if (cache != nullptr) {
+            int const frame = efpip->frame + efpip->add_frame;
+            if (frame == 0 || frame < cache->frame || cache_exists_flag == 0)
+                // 新規キャッシュ，あるいは時間が巻き戻っているなら初期化．
+                std::memset(cache, 0, 2 * sizeof(*cache));
+            else if (cache->frame == frame)
+                // 同一フレームなので音声ソースの更新．読み込み元を巻き戻す．
+                cache->states[0] = cache->states[1];
+            else cache->states[1] = cache->states[0];
+            cache->frame = frame;
+
+            noise_generator.recall(static_cast<int>(efp->processing), cache->states[0]);
+        }
+        noise_generator.step = step;
+    }
+
     short(__cdecl * func)(double rate);
     switch (exdata->type) {
     case 0: {
@@ -145,6 +205,9 @@ BOOL func_proc(ExEdit::Filter* efp, ExEdit::FilterProcInfo* efpip) {
     }break;
     case 5: {
         (func) = pulse_one_eighth;
+    }break;
+    case 6: {
+        (func) = white_noise;
     }break;
     default: {
         return FALSE;
@@ -168,12 +231,14 @@ BOOL func_proc(ExEdit::Filter* efp, ExEdit::FilterProcInfo* efpip) {
         }
     }
     exdata->last_rate = (float)rate;
+    if (cache != nullptr) cache->states[0] = noise_generator.state;
 
 
     return TRUE;
 }
 BOOL func_init(ExEdit::Filter* efp) {
     (update_any_exdata) = reinterpret_cast<decltype(update_any_exdata)>((int)efp->exedit_fp->dll_hinst + 0x4a7e0);
+    (get_or_create_cache) = reinterpret_cast<decltype(get_or_create_cache)>(get_func_address((int)efp->exedit_fp->dll_hinst + 0x1c1ea));
 
     for (int i = 0; i < 9; i++) {
         preset_scale[i] = 1375.0 * pow(2.0, (double)(i + 3) / 12.0);

--- a/src.cpp
+++ b/src.cpp
@@ -174,7 +174,7 @@ BOOL func_proc(ExEdit::Filter* efp, ExEdit::FilterProcInfo* efpip) {
             int const frame = efpip->frame + efpip->add_frame;
             if (frame == 0 || frame < cache->frame || cache_exists_flag == 0)
                 // 新規キャッシュ，あるいは時間が巻き戻っているなら初期化．
-                std::memset(cache, 0, 2 * sizeof(*cache));
+                std::memset(cache, 0, sizeof(*cache));
             else if (cache->frame == frame)
                 // 同一フレームなので音声ソースの更新．読み込み元を巻き戻す．
                 cache->states[0] = cache->states[1];


### PR DESCRIPTION
波形パターンにホワイトノイズを追加してみました．周波数を変化させることで「ホワイトノイズの高さ」（時間分解能）も変化します．

初代ファミコン時代では音源にホワイトノイズの機能があって，高いノイズでマラカスやシンバルを，低いノイズで地鳴りの音など，音の高さを変化させて様々なSEを構成していたらしいので，なにかと遊べると思います．

`philox4x32.hpp` は乱数生成アルゴリズムを記述したヘッダーファイルです．$n$ 番目の乱数位置に移動するまでの計算時間が $O(1)$ なのが，今回の用途に都合がいいので採用しました．乱数の統計的な質に関しては全く分かりませんが，C++26 の標準ライブラリに入る予定のものらしいので，悪くはないはずだと思います．(参考: https://en.cppreference.com/w/cpp/numeric/random/philox_engine)

以上，ご確認していただければと思います．